### PR TITLE
Remove prefix utility mixins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "aanzee-harbour",
 	"description": "Global component library",
-	"version": "1.1.10",
+	"version": "1.2.0",
 	"author": "Aan Zee",
 	"license": "MIT",
 	"repository": {

--- a/scss/utilities/backdrop-filter.scss
+++ b/scss/utilities/backdrop-filter.scss
@@ -1,4 +1,0 @@
-@mixin backdrop-filter($function) {
-	-webkit-backdrop-filter: $function;
-	backdrop-filter: $function;
-}

--- a/scss/utilities/index.scss
+++ b/scss/utilities/index.scss
@@ -3,5 +3,3 @@
 @import 'font-smoothing';
 @import 'media';
 @import 'ie-checks';
-@import 'position-sticky';
-@import 'backdrop-filter';

--- a/scss/utilities/position-sticky.scss
+++ b/scss/utilities/position-sticky.scss
@@ -1,4 +1,0 @@
-@mixin position-sticky{
-	position: -webkit-sticky;
-	position: sticky;
-}


### PR DESCRIPTION
Since we're using autoprefixer in our new projects these days, we can remove our prefix utilities.