### PR TITLE
Feature/GitHub pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ node_js:
 before_install:
   - rvm install 2.5.1
 
-install: gem install jekyll
-
-before_script:
+install:
+  - bundle install
+  - npm install
   - npm install -g gulp-cli
 
 script: npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "6"
   - "8"
   - "10"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ node_js:
   - "8"
   - "10"
 
+before_install:
+  - rvm install 2.5.1
+
+install: gem install jekyll
+
 before_script:
   - npm install -g gulp-cli
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.3)
+    jekyll (3.8.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -60,4 +60,4 @@ DEPENDENCIES
   jekyll (~> 3.8)
 
 BUNDLED WITH
-   1.16.3
+   1.16.6

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 [![Build Status](https://travis-ci.com/AanZee/harbour.svg?branch=master)](https://travis-ci.com/AanZee/harbour)
 
 ## About
-Global component library
+[See Github Pages](https://aanzee.github.io/harbour)
 
 ## Docs
-[See documentation](docs/README.md)
+[See documentation](https://aanzee.github.io/harbour/docs)
 
 ## License
 [MIT](LICENSE.md)

--- a/_config.yml
+++ b/_config.yml
@@ -5,4 +5,4 @@ highlighter: rouge
 # Settings
 source: "site"
 destination: ./_gh_pages
-# baseurl: "/harbour"
+baseurl: "/harbour"

--- a/_config.yml
+++ b/_config.yml
@@ -2,5 +2,7 @@
 markdown: kramdown
 highlighter: rouge
 
+# Settings
 source: "site"
 destination: ./_gh_pages
+# baseurl: "/harbour"

--- a/_config.yml
+++ b/_config.yml
@@ -5,4 +5,3 @@ highlighter: rouge
 # Settings
 source: "site"
 destination: ./_gh_pages
-baseurl: "/harbour"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,22 +1,20 @@
-var browserSync = require('browser-sync').create();
-var child = require('child_process');
-var gulp = require('gulp');
-var sass = require('gulp-sass');
-var postcss = require('gulp-postcss');
-var gutil = require('gulp-util');
-var postcssScssParser = require('postcss-scss');
-var postcssReporter = require('postcss-reporter');
-var autoprefixer = require('autoprefixer');
-var tildeImporter = require('node-sass-tilde-importer');
-var stylelint = require('stylelint');
+const autoprefixer = require('autoprefixer');
+const browserSync = require('browser-sync').create();
+const child = require('child_process');
+const gulp = require('gulp');
+const gutil = require('gulp-util');
+const postcss = require('gulp-postcss');
+const postcssReporter = require('postcss-reporter');
+const postcssScssParser = require('postcss-scss');
+const sass = require('gulp-sass');
+const stylelint = require('stylelint');
+const tildeImporter = require('node-sass-tilde-importer');
 
-var harbourStylelintJson = '.stylelintrc.json';
+const harbourStylelintJson = '.stylelintrc.json';
 
-var jekyllSiteRoot = '_gh_pages';
-
-var scssIndex = 'scss/index.scss';
-var scssGlobs = 'scss/**/*.scss';
-var stylelintGlobs = [
+// First we define all scss files to watch. Not all watched files need linting, so we define a second glob
+const scssGlobs = 'scss/**/*.scss';
+const stylelintGlobs = [
 	'scss/components/*.scss',
 	'scss/controls/*.scss',
 	'scss/layouts/*.scss',
@@ -25,7 +23,12 @@ var stylelintGlobs = [
 	'scss/vendor-overrides/*.scss',
 	'!scss/**/index.scss'
 ];
-var cssFolder = 'site/css/';
+const scssIndex = 'scss/index.scss';
+
+// Compiled css is placed in Jekyll source folder.
+const cssFolder = 'site/css/';
+// Destination for build Jekyll site.
+const jekyllSiteRoot = '_gh_pages';
 
 /**
  * stylelintScss
@@ -63,8 +66,8 @@ function stylelintScss(isBuild) {
  * @param {Boolean} isBuild
  */
 function compileScss(isBuild) {
-	var outputStyle = isBuild ? 'compressed' : 'expanded';
-	var hasCompilerError = false;
+	const outputStyle = isBuild ? 'compressed' : 'expanded';
+	const hasCompilerError = false;
 
 	return gulp.src(scssIndex)
 		.pipe(
@@ -92,50 +95,17 @@ function compileScss(isBuild) {
 }
 
 /**
- * getTimestamp
- * Return current time
+ * buildJekyll
+ * Compile Jekyll website from source
+ * @param {Boolean} isWatch - To exit main process when an error occurs in Jekyll while watching
+ * @param {Array} options - Flags to pass to the jekyll process
  */
-function getTimestamp() {
-	var time = new Date();
-	var hours = time.getHours();
-	var minutes = time.getMinutes();
-	var seconds = time.getSeconds();
+function buildJekyll(isWatch, options) {
+	const arguments = ['build'].concat(options);
 
-	return hours + ':' + minutes + ':' + seconds;
-}
+	const jekyll = child.spawn('jekyll', arguments);
 
-gulp.task('stylelintScss', function() {
-	var isBuild = false;
-	gulp.watch(scssGlobs, function() {
-		return stylelintScss(isBuild);
-	});
-});
-
-gulp.task('compileScss', ['stylelintScss'], function() {
-	var isBuild = false;
-	gulp.watch(scssGlobs, function() {
-		return compileScss(isBuild);
-	});
-});
-
-gulp.task('buildStylelintScss', function() {
-	var isBuild = true;
-	return stylelintScss(isBuild);
-});
-
-gulp.task('buildScss', ['buildStylelintScss'], function() {
-	var isBuild = true;
-	return compileScss(isBuild);
-});
-
-gulp.task('watchJekyll', () => {
-	var jekyll = child.spawn('jekyll', ['build',
-		'--watch',
-		'--incremental',
-		'--drafts',
-	]);
-
-	var jekyllLogger = (buffer) => {
+	const jekyllLogger = (buffer) => {
 		buffer.toString()
 			.split(/\n/)
 			.forEach((message) => gutil.log('Jekyll: ' + message));
@@ -143,6 +113,67 @@ gulp.task('watchJekyll', () => {
 
 	jekyll.stdout.on('data', jekyllLogger);
 	jekyll.stderr.on('data', jekyllLogger);
+
+	if (isWatch) {
+		jekyll.on('close', (code) => {
+			console.log(`Jekyll process exited with code ${code}, stopping Gulp task`);
+			process.exit();
+		});
+	}
+}
+
+/**
+ * getTimestamp
+ * Return current time
+ */
+function getTimestamp() {
+	const time = new Date();
+	const hours = time.getHours();
+	const minutes = time.getMinutes();
+	const seconds = time.getSeconds();
+
+	return hours + ':' + minutes + ':' + seconds;
+}
+
+gulp.task('stylelintScss', function() {
+	const isBuild = false;
+	gulp.watch(scssGlobs, function() {
+		return stylelintScss(isBuild);
+	});
+});
+
+gulp.task('compileScss', ['stylelintScss'], function() {
+	const isBuild = false;
+	gulp.watch(scssGlobs, function() {
+		return compileScss(isBuild);
+	});
+});
+
+gulp.task('buildStylelintScss', function() {
+	const isBuild = true;
+	return stylelintScss(isBuild);
+});
+
+gulp.task('buildScss', ['buildStylelintScss'], function() {
+	const isBuild = true;
+	return compileScss(isBuild);
+});
+
+gulp.task('watchJekyll', () => {
+	const isWatch = true;
+	const options = [
+		'--watch', // Enable auto-regeneration of the site when files are modified
+		'--incremental', // Only re-build pages that have changed
+	];
+
+	return buildJekyll(isWatch, options);
+});
+
+gulp.task('buildJekyllSite', ['buildScss'], function() {
+	const isWatch = false;
+	const options = [];
+
+	return buildJekyll(isWatch, options);
 });
 
 gulp.task('serveJekyll', () => {
@@ -157,4 +188,4 @@ gulp.task('serveJekyll', () => {
 
 // CLI Tasks
 gulp.task('start', ['compileScss', 'watchJekyll', 'serveJekyll']);
-gulp.task('build', ['buildScss']);
+gulp.task('build', ['buildJekyllSite']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ const postcssScssParser = require('postcss-scss');
 const sass = require('gulp-sass');
 const stylelint = require('stylelint');
 const tildeImporter = require('node-sass-tilde-importer');
+const packageJson = require('./package.json');
 
 const harbourStylelintJson = '.stylelintrc.json';
 
@@ -102,8 +103,10 @@ function compileScss(isBuild) {
  */
 function buildJekyll(isWatch, options) {
 	const arguments = ['build'].concat(options);
+	const env = Object.create( process.env );
+	env.packageVersion = packageJson.version;
 
-	const jekyll = child.spawn('jekyll', arguments);
+	const jekyll = child.spawn('jekyll', arguments, { env: env });
 
 	const jekyllLogger = (buffer) => {
 		buffer.toString()

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	},
 	"scripts": {
 		"start": "gulp start",
-		"build": "gulp build"
+		"build": "JEKYLL_BASE_URL=harbour gulp build"
 	},
 	"dependencies": {
 		"bourbon": "5.0.0",

--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -1,4 +1,4 @@
 <meta charset="utf-8">
 <meta name="viewport" content="initial-scale=1.0, maximum-scale=1, width=device-width, user-scalable=no">
 <title>Harbour Styleguide{%- if page.title -%}&nbsp;&middot; {{ page.title }}{% endif %}</title>
-<link rel="stylesheet" href="/css/index.css">
+<link rel="stylesheet" href="{{ '/css/index.css' | relative_url }}">

--- a/site/_includes/page-footer.html
+++ b/site/_includes/page-footer.html
@@ -4,4 +4,11 @@
 			When I'm not surfing or sailing, I am to be found at the harbour working on my boat.
 		</div>
 	</div>
+	<div class="layout__section layout__section--spaced-0 layout__section--dark">
+		<div class="layout__inner layout__inner--padded-top-bottom-70">
+			<div class="content content--90 content--light">
+				Harbour {{ site.packageVersion }} generated on {{ site.time | date: "%-d %B %Y - %R"}}
+			</div>
+		</div>
+	</div>
 </section>

--- a/site/_includes/page-header.html
+++ b/site/_includes/page-header.html
@@ -3,7 +3,7 @@
 		<div class="layout__inner layout__inner--padded-top-bottom-80">
 			<header class="heading-group">
 				<h1 class="heading-group__title">
-					<a href="/">
+					<a href="{{ '/' | relative_url }}">
 						Harbour
 					</a>
 				</h1>

--- a/site/_layouts/docs.html
+++ b/site/_layouts/docs.html
@@ -22,7 +22,7 @@
 							<div class="layout__column layout__column--one-third">
 								<div class="layout__section layout__section--right-aligning layout__section--vertical-centering">
 									<a class="button button--90"
-										href="/docs"
+										href="{{ '/docs' | relative_url }}"
 									>
 										Back to documentation
 									</a>

--- a/site/_plugins/environment_variables.rb
+++ b/site/_plugins/environment_variables.rb
@@ -1,0 +1,14 @@
+module Jekyll
+
+	class EnvironmentVariablesGenerator < Generator
+		priority :highest
+
+	def generate(site)
+		site.config['env'] = ENV['JEKYLL_ENV'] || 'development'
+		site.config['baseurl'] = ENV['JEKYLL_BASE_URL'] || ''
+		site.config['packageVersion'] = ENV['packageVersion'] || 'reset'
+		# Add other environment variables to `site.config` here...
+		Jekyll.logger.debug site.config.to_yaml
+		end
+	end
+end

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -4,17 +4,17 @@ title: Documentation
 ---
 
 ## Components
-* [Content](/docs/components/content.html)
-* [Dialog](/docs/components/dialog.html)
-* [Popover](/docs/components/popover.html)
+* [Content]({{ '/docs/components/content.html' | relative_url }})
+* [Dialog]({{ '/docs/components/dialog.html' | relative_url }})
+* [Popover]({{ '/docs/components/popover.html' | relative_url }})
 
 ## Controls
-* [Button](/docs/controls/button.html)
-* [Drop-down menu](/docs/controls/drop-down-menu.html)
-* [Input stepper](/docs/controls/input-stepper.html)
-* [Password input](/docs/controls/password-input.html)
-* [Text input](/docs/controls/text-input.html)
+* [Button]({{ '/docs/controls/button.html' | relative_url }})
+* [Drop-down menu]({{ '/docs/controls/drop-down-menu.html' | relative_url }})
+* [Input stepper]({{ '/docs/controls/input-stepper.html' | relative_url }})
+* [Password input]({{ '/docs/controls/password-input.html' | relative_url }})
+* [Text input]({{ '/docs/controls/text-input.html' | relative_url }})
 
 ## Layouts
-* [Layout](/docs/layouts/layout.html)
-* [Page](/docs/layouts/page.html)
+* [Layout]({{ '/docs/layouts/layout.html' | relative_url }})
+* [Page]({{ '/docs/layouts/page.html' | relative_url }})

--- a/site/index.md
+++ b/site/index.md
@@ -14,7 +14,7 @@ npm install aanzee-harbour
 ```
 
 ### Documentation
-A detailed explanation of all the components and how to use them can be found in the [documentation section](/docs).
+A detailed explanation of all the components and how to use them can be found in the [documentation section]({{ '/docs' | relative_url }}).
 
 ## Contributing
 I you want to contribute to this project you can create a pull request on [Github](https://github.com/AanZee/harbour).
@@ -26,10 +26,10 @@ First install `bundler` and `jekyll` gems.
 gem install bundler jekyll
 ```
 
-Checkout the project and open the root folder in your terminal. Run an `npm install` to install all dependencies.
+Checkout the project and open the root folder in your terminal. Run `npm install` to install all dependencies.
 
 ```bash
-npm run install
+npm install
 npm run start
 ```
 

--- a/site/index.md
+++ b/site/index.md
@@ -34,3 +34,25 @@ npm run start
 ```
 
 A browser window should open and point to `http://localhost:4000`. SCSS linting and live reloading is implemented into the task.
+
+### Github Pages documentation
+The static (Jekyll) documentation is hosted on Github Pages. The documentation is generated from the `master` branch and copied to a `gh-pages` branch.
+
+#### Building the documentation
+Checkout the `master` branch and generate the documentation:
+```bash
+git checkout master
+npm install
+npm run build
+```
+
+#### Committing generated documentation
+Switch to the `gh-pages` (orphan) branch. The generated static website is placed in the `_gh_pages` folder, which is in the `.gitignore` on both branches, so the files are still there when switching branches.
+```bash
+git checkout gh-pages
+```
+
+Remove `index.html`, and the folders `css` & `docs` from the root of the project. Copy the folders from the `_gh_pages` folder to the root of your project. Commit all changes to the `gh-pages` 
+
+#### Deploying to Github Pages
+Push the `gh-pages` branch to Github. The new version should now be present on [Github Pages](https://aanzee.github.io/harbour)


### PR DESCRIPTION
Adjustments to Gulp tasks and documentation files so that the generated Jekyll website can be deployed to Github Pages.

See https://aanzee.github.io/harbour/ for the current generated version. Updating the documentation is also documented there (so meta...).

