### PR TITLE
[HAR-223] Add code block collapse control

### DIFF
--- a/site/_includes/example.html
+++ b/site/_includes/example.html
@@ -30,7 +30,7 @@
 						<div class="layout">
 							<div class="{{ layoutClasses }}">
 								{%- highlight html -%}
-								{{- include.content | replace: 'data-src="holder.js', 'src="...' -}}
+									{{- include.content -}}
 								{%- endhighlight -%}
 							</div>
 						</div>

--- a/site/_includes/example.html
+++ b/site/_includes/example.html
@@ -26,7 +26,7 @@
 	<!-- Default example including visual example and code example -->
 	{%- if include.show-code-example-only == null and include.show-visual-example-only == null -%}
 		{{ visual-example }}
-		<div class="layout__section layout__section--spaced-0 layout__section--rounded-bottom">
+		<div class="layout__section layout__section--bordered-top layout__section--spaced-0">
 			<label class="collapsible">
 				<input class="collapsible__input"
 					type="checkbox"
@@ -34,7 +34,11 @@
 				<div class="collapsible__label collapsible__label--show"></> Show code</div>
 				<div class="collapsible__label collapsible__label--hide"></> Hide code</div>
 				<div class="collapsible__content">
-					{{ code-example }}
+					<div class="layout">
+						<div class="layout__section layout__section--bordered-top layout__section--rounded-bottom">
+							{{ code-example }}
+						</div>
+					</div>
 				</div>
 			</label>
 		</div>

--- a/site/_includes/example.html
+++ b/site/_includes/example.html
@@ -3,57 +3,32 @@
 </div>
 {:/nomarkdown}
 
-<!-- Visual example snippet -->
-{% capture visual-example %}
-<div class="layout__section">
-	<div class="layout__inner layout__inner--padded-90">
-		<div>
-			{{- include.content -}}
+<div class="layout__section layout__section--spaced-70 layout__section--fitted layout__section--bordered layout__section--rounded">
+	<div class="layout__section">
+		<div class="layout__inner layout__inner--padded-90">
+			<div>
+				{{- include.content -}}
+			</div>
 		</div>
 	</div>
-</div>
-{% endcapture %}
-
-<!-- Code example snippet -->
-{% capture code-example %}
-	{%- highlight html -%}
-		{{- include.content -}}
-	{%- endhighlight -%}
-{% endcapture %}
-
-<div class="layout__section layout__section--spaced-70 layout__section--fitted layout__section--bordered layout__section--rounded">
-
-	<!-- Default example including visual example and code example -->
-	{%- if include.show-code-example-only == null and include.show-visual-example-only == null -%}
-		{{ visual-example }}
-		<div class="layout__section layout__section--bordered-top layout__section--spaced-0">
-			<label class="collapsible">
-				<input class="collapsible__input"
-					type="checkbox"
-				>
-				<div class="collapsible__label collapsible__label--show"></> Show code</div>
-				<div class="collapsible__label collapsible__label--hide"></> Hide code</div>
-				<div class="collapsible__content">
-					<div class="layout">
-						<div class="layout__section layout__section--bordered-top layout__section--rounded-bottom">
-							{{ code-example }}
-						</div>
+	<div class="layout__section layout__section--bordered-top layout__section--spaced-0">
+		<label class="collapsible">
+			<input class="collapsible__input"
+				type="checkbox"
+			>
+			<div class="collapsible__label collapsible__label--show"></> Show code</div>
+			<div class="collapsible__label collapsible__label--hide"></> Hide code</div>
+			<div class="collapsible__content">
+				<div class="layout">
+					<div class="layout__section layout__section--bordered-top layout__section--rounded-bottom">
+						{%- highlight html -%}
+							{{- include.content -}}
+						{%- endhighlight -%}
 					</div>
 				</div>
-			</label>
-		</div>
-	{%- endif -%}
-
-	<!-- Visual example only -->
-	{%- if include.show-visual-example-only -%}
-		{{ visual-example }}
-	{%- endif -%}
-
-	<!-- Code example only -->
-	{%- if include.show-code-example-only -%}
-		{{ code-example }}
-	{%- endif -%}
-
+			</div>
+		</label>
+	</div>
 </div>
 
 <div class="layout__section">

--- a/site/_includes/example.html
+++ b/site/_includes/example.html
@@ -15,19 +15,27 @@
 					</div>
 				</div>
 			{%- endif -%}
-
 			{%- if include.hide_markup == null -%}
 				{% assign layoutClasses="layout__section layout__section--spaced-0 layout__section--rounded-bottom" %}
 				{%- if include.hide_preview == null -%}
 					{% assign layoutClasses="layout__section layout__section--spaced-0 layout__section--rounded-bottom layout__section--bordered-top" %}
 				{%- endif -%}
-				<div
-					class="{{ layoutClasses }}"
-				>
-					{%- highlight html -%}
-						{{- include.content | replace: 'data-src="holder.js', 'src="...' -}}
-					{%- endhighlight -%}
-				</div>
+				<label class="collapsible">
+					<input class="collapsible__input"
+						type="checkbox"
+					>
+					<div class="collapsible__label collapsible__label--show"></> Show code</div>
+					<div class="collapsible__label collapsible__label--hide"></> Hide code</div>
+					<div class="collapsible__content">
+						<div class="layout">
+							<div class="{{ layoutClasses }}">
+								{%- highlight html -%}
+								{{- include.content | replace: 'data-src="holder.js', 'src="...' -}}
+								{%- endhighlight -%}
+							</div>
+						</div>
+					</div>
+				</label>
 			{%- endif -%}
 		</div>
 	{% endif %}

--- a/site/_includes/example.html
+++ b/site/_includes/example.html
@@ -3,42 +3,53 @@
 </div>
 {:/nomarkdown}
 
+<!-- Visual example snippet -->
+{% capture visual-example %}
 <div class="layout__section">
-	{% if include.content %}
-		<div class="layout__section layout__section--fitted layout__section--spaced-80 layout__section--bordered layout__section--rounded">
-			{%- if include.hide_preview == null -%}
-				<div class="layout__section">
-					<div class="layout__inner layout__inner--padded-90">
-						<div>
-							{{- include.content -}}
-						</div>
-					</div>
-				</div>
-			{%- endif -%}
-			{%- if include.hide_markup == null -%}
-				{% assign layoutClasses="layout__section layout__section--spaced-0 layout__section--rounded-bottom" %}
-				{%- if include.hide_preview == null -%}
-					{% assign layoutClasses="layout__section layout__section--spaced-0 layout__section--rounded-bottom layout__section--bordered-top" %}
-				{%- endif -%}
-				<label class="collapsible">
-					<input class="collapsible__input"
-						type="checkbox"
-					>
-					<div class="collapsible__label collapsible__label--show"></> Show code</div>
-					<div class="collapsible__label collapsible__label--hide"></> Hide code</div>
-					<div class="collapsible__content">
-						<div class="layout">
-							<div class="{{ layoutClasses }}">
-								{%- highlight html -%}
-									{{- include.content -}}
-								{%- endhighlight -%}
-							</div>
-						</div>
-					</div>
-				</label>
-			{%- endif -%}
+	<div class="layout__inner layout__inner--padded-90">
+		<div>
+			{{- include.content -}}
 		</div>
-	{% endif %}
+	</div>
+</div>
+{% endcapture %}
+
+<!-- Code example snippet -->
+{% capture code-example %}
+	{%- highlight html -%}
+		{{- include.content -}}
+	{%- endhighlight -%}
+{% endcapture %}
+
+<div class="layout__section layout__section--spaced-70 layout__section--fitted layout__section--bordered layout__section--rounded">
+
+	<!-- Default example including visual example and code example -->
+	{%- if include.show-code-example-only == null and include.show-visual-example-only == null -%}
+		{{ visual-example }}
+		<div class="layout__section layout__section--spaced-0 layout__section--rounded-bottom">
+			<label class="collapsible">
+				<input class="collapsible__input"
+					type="checkbox"
+				>
+				<div class="collapsible__label collapsible__label--show"></> Show code</div>
+				<div class="collapsible__label collapsible__label--hide"></> Hide code</div>
+				<div class="collapsible__content">
+					{{ code-example }}
+				</div>
+			</label>
+		</div>
+	{%- endif -%}
+
+	<!-- Visual example only -->
+	{%- if include.show-visual-example-only -%}
+		{{ visual-example }}
+	{%- endif -%}
+
+	<!-- Code example only -->
+	{%- if include.show-code-example-only -%}
+		{{ code-example }}
+	{%- endif -%}
+
 </div>
 
 <div class="layout__section">

--- a/site/_layouts/docs.html
+++ b/site/_layouts/docs.html
@@ -12,7 +12,6 @@
 			user-select: none;
 			justify-content: center;
 			padding: 8px;
-			border-top: 1px solid #f0f1f3;
 			color: #3185fc;
 			font-size: 12px;
 			font-weight: 600;

--- a/site/_layouts/docs.html
+++ b/site/_layouts/docs.html
@@ -4,6 +4,7 @@
 	<style>
 		.collapsible {
 			position: relative;
+			overflow: hidden;
 		}
 
 		.collapsible__label {

--- a/site/_layouts/docs.html
+++ b/site/_layouts/docs.html
@@ -1,5 +1,51 @@
 <!doctype html>
 <html lang="en">
+	<!-- NOTE: Collapsible styling is added for the code block toggle in example.html -->
+	<style>
+		.collapsible {
+			position: relative;
+		}
+
+		.collapsible__label {
+			display: flex;
+			user-select: none;
+			justify-content: center;
+			padding: 8px;
+			border-top: 1px solid #f0f1f3;
+			color: #3185fc;
+			font-size: 12px;
+			font-weight: 600;
+			cursor: pointer;
+		}
+
+		.collapsible__input:checked ~ .collapsible__label--show {
+			display: none;
+		}
+
+		.collapsible__label--hide {
+			display: none;
+		}
+
+		.collapsible__input:checked ~ .collapsible__label--hide {
+			display: flex;
+		}
+
+		.collapsible__input {
+			position: absolute;
+			top: 0;
+			visibility: hidden;
+		}
+
+		.collapsible__content {
+			overflow: hidden;
+			max-height: 0px;
+		}
+
+		.collapsible__input:checked ~ .collapsible__content {
+			max-height: none;
+		}
+	</style>
+
 	<head>
 		{% include head.html %}
 	</head>

--- a/site/docs/controls/button.md
+++ b/site/docs/controls/button.md
@@ -35,13 +35,13 @@ The classes belonging to the `button` component can be used to style both the `<
 
 ## Available modifiers
 ### Colors
-{% capture example %}
+{% capture button-colors %}
 <button class="button button--call-to-action" type="button">button--call-to-action</button>
 <button class="button button--primary" type="button">button--primary</button>
 <button class="button button--secondary" type="button">button--secondary</button>
 {% endcapture %}
 {% include example.html
-	content=example
+	content=button-colors
 %}
 
 ### Outline version (available in all colors)

--- a/site/docs/layouts/page.md
+++ b/site/docs/layouts/page.md
@@ -33,5 +33,5 @@ page
 {% endcapture %}
 {% include example.html
 	content=page
-	hide_preview=true
+	show-code-example-only=true
 %}

--- a/site/docs/layouts/page.md
+++ b/site/docs/layouts/page.md
@@ -17,8 +17,7 @@ page
 ```
 
 ## Example HTML
-
-{% capture page %}
+```html
 <body class="page">
 	<header class="page__header">
 		...
@@ -30,8 +29,4 @@ page
 		...
 	</footer>
 </body>
-{% endcapture %}
-{% include example.html
-	content=page
-	show-code-example-only=true
-%}
+```


### PR DESCRIPTION
Issue key: [HAR-223]

## Summary of your proposal
Enables collapsing code blocks and improves readability of example.html

## Proposed changes in this pull request:

* Add collapsible styling to docs.html as this styling does not belong to the UI-library style
* Add collapsible functionality to example.html to enable collapsing code blocks
* Improve readability of example.html

## Proposed additions to the CHANGELOG.md

### Feature

* Enables collapsing code blocks