### PR TITLE
Remove deprecated layout__section--spacing-100 modifier

### DIFF
--- a/site/_layouts/docs.html
+++ b/site/_layouts/docs.html
@@ -82,7 +82,7 @@
 				</div>
 				<div class="layout__section layout__section--spaced-0">
 					<div class="layout__inner">
-						<div class="layout__section layout__section--spacing-100">
+						<div class="layout__section">
 							<div class="layout__section">
 								<section class="content">
 									{{ content }}

--- a/site/docs/_layouts/layout.md
+++ b/site/docs/_layouts/layout.md
@@ -5,7 +5,7 @@ title: Layout
 
 ## Available modifiers
 
-Available `city block sizes` modifiers are mentioned between parenthesis. Since 100 is the default `city block`, it is only available for the `layout__section--spacing-100`.
+Available `city block sizes` modifiers are mentioned between parenthesis.
 
 ### Adjust space between sections
 ```
@@ -14,7 +14,7 @@ layout__section--spaced-0 (60, 70, 80, 90, 200, 300)
 
 ### Adjust space between children
 ```
-layout__section--spacing-60 (60, 70, 80, 90, 100, 200, 300)
+layout__section--spacing-0 (60, 70, 80, 90, 200, 300)
 ```
 
 ### Adjust section appearance


### PR DESCRIPTION
## Checklist
- [x] Code follows the [Aan Zee conventions](https://github.com/aanzee/conventions)
- [x] SCSS imports are sorted alphabetically (when possible)

## Summary of your proposal
I want to remove the [deprecated](https://github.com/AanZee/harbour/releases/tag/1.22.0) layout__section--spacing-100 modifier in HTML and docs.