### PR TITLE
Feature/har 148 add text width variable

### DIFF
--- a/scss/components/content.scss
+++ b/scss/components/content.scss
@@ -54,7 +54,17 @@ $content-table-cell-padding-lap-and-larger: $spacing * 1.5;
 	color: $color-text-light;
 }
 
-// TODO HAR-148: Add content width modifiers (--expanded, narrow, etc) when text width setting is added
+.content--max-width-90 {
+	max-width: $text-width-90;
+}
+
+.content--max-width-200 {
+	max-width: $text-width-200;
+}
+
+.content--stretched {
+	max-width: none;
+}
 
 h1 {
 

--- a/scss/components/content.scss
+++ b/scss/components/content.scss
@@ -4,7 +4,7 @@ $content-table-cell-padding-hand-and-smaller: $spacing;
 $content-table-cell-padding-lap-and-larger: $spacing * 1.5;
 
 .content {
-	max-width: 40em;
+	max-width: $text-width-100;
 	line-height: $line-height-60;
 
 	@include media(0, $range-hand) {

--- a/scss/controls/checkbox.scss
+++ b/scss/controls/checkbox.scss
@@ -14,7 +14,7 @@ $checkbox-input-label-spacing: $spacing !default;
 	padding-bottom: (($control-size-100 - ($font-size-200 * $line-height-60)) / 2);
 	padding-left: $checkbox-input-size + $checkbox-input-label-spacing;
 	min-height: $control-size-100;
-	max-width: $text-width-200;
+	max-width: $text-width-100;
 	font-size: $font-size-200;
 	line-height: $line-height-60;
 	cursor: default;

--- a/scss/controls/checkbox.scss
+++ b/scss/controls/checkbox.scss
@@ -14,7 +14,7 @@ $checkbox-input-label-spacing: $spacing !default;
 	padding-bottom: (($control-size-100 - ($font-size-200 * $line-height-60)) / 2);
 	padding-left: $checkbox-input-size + $checkbox-input-label-spacing;
 	min-height: $control-size-100;
-	max-width: 40em;
+	max-width: $text-width-200;
 	font-size: $font-size-200;
 	line-height: $line-height-60;
 	cursor: default;

--- a/site/docs/_components/content.md
+++ b/site/docs/_components/content.md
@@ -3,6 +3,32 @@ layout: docs
 title: Content
 ---
 
+## Available modifiers
+
+### Font size
+```
+content--90
+content--200
+```
+
+### Alignment
+```
+content--centered
+content--centering
+```
+
+### Appearance
+```
+content--light
+```
+
+### Text length
+```
+content--max-width-90
+content--max-width-200
+content--stretched
+```
+
 ## Headings
 {% capture content-headings %}
 <section class="content">


### PR DESCRIPTION
Jira id: [HAR-148]
Documentation url: https://harbour.aanzee.cc/feature/HAR-148-add-text-width-variable

## Checklist
- [x] Code follows the [Aan Zee conventions](https://github.com/aanzee/conventions)
- [x] SCSS imports are sorted alphabetically (when possible)

## Summary of your proposal
Add text-width variables to content and checkbox elements.

## Proposed changes in this pull request:
* Replace content max width value by the sizing variable `$text-width-100`
* Add max width modifiers `content--max-width-90`, `content--max-width-200` and `content--stretched` to content component
* Replace checkbox max width value by the sizing variable `$text-width-200`
* Add modifier overview to content documentation

## Proposed additions to the CHANGELOG.md

### Feature
* Add max width modifiers `content--max-width-90`, `content--max-width-200` and `content--stretched` to content component

### Improvements
* Replace content max width value by the sizing variable `$text-width-100`
* Replace checkbox max width value by the sizing variable `$text-width-200`